### PR TITLE
Make sure parent folder exists before creating symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## MASTER
 
+## 0.1.4
+* Make sure parent folder exists before creating symlink.
+
 ## 0.1.3
 * Add CHANGELOG.md
 * Check cerbot_current_server status before starting or stoping it,

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
       versions:
         - trusty  # 14.04
         - xenial  # 16.04
+        - bionic  # 18.04
   galaxy_tags:
     - certbot
     - certificate

--- a/tasks/https.yml
+++ b/tasks/https.yml
@@ -32,6 +32,13 @@
     --agree-tos -n
     '
 
+- name: Create '{{ certbot_current_server }}' folder
+  file:
+    path: '/etc/{{ certbot_current_server }}'
+    owner: root
+    mode: 0755
+    state: directory
+
 - name: Create symbolic links
   file:
     src: '{{ certbot_letsencrypt_path }}'


### PR DESCRIPTION
The first time when running this role before the apache/nginx/etc role, the symlink can only be created if the parent directory exists; this creates it. 